### PR TITLE
None/NaN values with bokeh_matplot

### DIFF
--- a/bebi103.py
+++ b/bebi103.py
@@ -61,7 +61,7 @@ def rgb_frac_to_hex(rgb_frac):
                                            int(rgb_frac[2] * 255))
 
 
-def data_to_hex_color(x, palette, x_range=[0, 1]):
+def data_to_hex_color(x, palette, x_range=[0, 1], na_value='#000000'):
     """
     Convert a value to a hexidecimal color according to
     color palette.
@@ -94,6 +94,8 @@ def data_to_hex_color(x, palette, x_range=[0, 1]):
         raise RuntimeError('data outside of range')
     elif x == x_range[1]:
         return rgb_frac_to_hex(palette[-1])
+    elif np.isnan(x):
+        return na_value
 
     # Fractional position of x in x_range
     f = (x - x_range[0]) / (x_range[1] - x_range[0])

--- a/bebi103.py
+++ b/bebi103.py
@@ -90,12 +90,12 @@ def data_to_hex_color(x, palette, x_range=[0, 1], na_value='#000000'):
     >>> data_to_hex_color(7.1, [(1, 0, 0), (0, 1, 0), (0, 0, 1)], [0, 10])
     '#0000ff'
     """
-    if x > x_range[1] or x < x_range[0]:
+    if x is None or np.isnan(x):
+        return na_value
+    elif x > x_range[1] or x < x_range[0]:
         raise RuntimeError('data outside of range')
     elif x == x_range[1]:
         return rgb_frac_to_hex(palette[-1])
-    elif np.isnan(x):
-        return na_value
 
     # Fractional position of x in x_range
     f = (x - x_range[0]) / (x_range[1] - x_range[0])

--- a/test_bebi103.py
+++ b/test_bebi103.py
@@ -31,7 +31,7 @@ def test_bokeh_boxplot():
 
 def test_bokeh_matplot():
     a = np.array([[1, 2, 3], [4, 5, 6], [7, 8, None]]).astype(float)
-    a[1, 1] = None 
+    a[1, 1] = None
     data = np.array(np.unravel_index(range(9), a.shape) + (a.ravel(),)).T
     df = pd.DataFrame(data, columns=['i', 'j', 'data'])
     bokeh.plotting.output_file('test_matplot.html')

--- a/test_bebi103.py
+++ b/test_bebi103.py
@@ -30,7 +30,8 @@ def test_bokeh_boxplot():
 
 
 def test_bokeh_matplot():
-    a = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    a = np.array([[1, 2, 3], [4, 5, 6], [7, 8, None]]).astype(float)
+    a[1, 1] = None 
     data = np.array(np.unravel_index(range(9), a.shape) + (a.ravel(),)).T
     df = pd.DataFrame(data, columns=['i', 'j', 'data'])
     bokeh.plotting.output_file('test_matplot.html')


### PR DESCRIPTION
In the course of plotting a heatmap with bebi103.bokeh_matplot, some of my data is `NaN`. It would be convenient to have these automatically mapped to a specific color out of the range of the colormap. `ggplot` handles this by having a `na.value` argument to the scale_\* layer (http://docs.ggplot2.org/0.9.3.1/scale_gradient.html). In that spirit, I’ve modified `data_to_hex_color` to implement a similar feature.
