### PR TITLE
Fixed line_width unused parameter in viz.contour

### DIFF
--- a/bebi103/viz.py
+++ b/bebi103/viz.py
@@ -1326,7 +1326,8 @@ def contour(X, Y, Z, levels=None, p=None, overlaid=False, plot_width=350,
         levels = 1.0 - np.exp(-np.arange(0.5, 2.1, 0.5)**2 / 2)
 
     # Compute contour lines
-    xs, ys = _contour_lines(X, Y, Z, levels)
+    if fill or line_width:
+        xs, ys = _contour_lines(X, Y, Z, levels)
 
     # Make fills. This is currently not supported
     if fill:
@@ -1361,7 +1362,8 @@ def contour(X, Y, Z, levels=None, p=None, overlaid=False, plot_width=350,
         p.background_fill_color=fill_palette[-1]
 
     # Populate the plot with contour lines
-    p.multi_line(xs, ys, line_color=line_color, line_width=2)
+    if line_width:
+        p.multi_line(xs, ys, line_color=line_color, line_width=line_width)
 
     if overlay_grid and overlaid:
         p.grid.level = 'overlay'


### PR DESCRIPTION
Fixing `line_width` bug in `bebi103.viz.contour`.

In line `1364` we have `p.multi_line(xs, ys, line_color=line_color, line_width=2)`, and the `line_width` parameter passed into `bebi103.viz.contour` is not used.

The buggy behavior can be reproduced by passing in any `line_width` to `contour` other than `2`, and seeing that it does not change.

After this change, a larger `line_width` will result in a thicker line, and `line_width=0` will result in no line at all.