### PR TITLE
Add codemeta file and prep for CaltechDATA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # bebi103
 
-Utilities Caltech BE/Bi 103: Data Analysis in the Biological Sciences
+[![DOI](https://data.caltech.edu/badge/44303442.svg)](https://data.caltech.edu/badge/latestdoi/44303442)
 
+Utilities Caltech BE/Bi 103: Data Analysis in the Biological Sciences
 
 ## Installation / Usage
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,29 @@
+{
+  "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
+  "@type": "SoftwareSourceCode",
+  "description": "Python utilities for the Caltech course BE/Bi 103: Data Analysis in the Biological Sciences.",
+  "name": "bebi103",
+  "codeRepository": "https://github.com/justinbois/bebi103",
+  "issueTracker": "https://github.com/justinbois/bebi103/issues",
+  "license": "https://spdx.org/licenses/BSD-3-Clause",
+  "version": "0.0.41",
+  "author": [
+    {
+      "@type": "Person",
+      "givenName": "Justin",
+      "familyName": "Bois",
+      "affiliation": "Caltech",
+      "email": "bois@caltech.edu",
+      "@id": "https://orcid.org/0000-0001-7137-8746"
+    }],
+  "developmentStatus": "active",
+  "downloadUrl": "https://github.com/justinbois/bebi103/releases",
+  "keywords": [
+    "GitHub",
+    "Python",
+    "Instruction",
+    "Biology"
+  ],
+  "maintainer": "https://orcid.org/0000-0001-7137-8746",
+  "programmingLanguage": "Python"
+}

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,43 @@
 from setuptools import setup, find_packages
 from codecs import open
 from os import path
+import json
 
-__version__ = '0.0.41'
+def read(fname):
+    with open(fname, mode = "r", encoding = "utf-8") as f:
+        src = f.read()
+    return src
+
+codemeta_json = "codemeta.json"
+
+# Let's pickup as much metadata as we need from codemeta.json
+with open(codemeta_json, mode = "r", encoding = "utf-8") as f:
+    src = f.read()
+    meta = json.loads(src)
+
+# Let's make our symvar string
+__version__ = meta["version"]
+
+# Now we need to pull and format our author, author_email strings.
+author = ""
+author_email = ""
+for obj in meta["author"]:
+    given = obj["givenName"]
+    family = obj["familyName"]
+    email = obj["email"]
+    if len(author) == 0:
+        author = given + " " + family
+    else:
+        author = author + ", " + given + " " + family
+    if len(author_email) == 0:
+        author_email = email
+    else:
+        author_email = author_email + ", " + email
+description = meta['description']
+url = meta['codeRepository']
+license = meta['license']
+name = meta['name']
+keywords= meta['keywords']
 
 here = path.abspath(path.dirname(__file__))
 
@@ -18,11 +53,11 @@ install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
 dependency_links = [x.strip().replace('git+', '') for x in all_reqs if x.startswith('git+')]
 
 setup(
-    name='bebi103',
+    name=name,
     version=__version__,
-    description='Python utilities for the Caltech course BE/Bi 103: Data Analysis in the Biological Sciences.',
+    description=description,
     long_description=long_description,
-    url='https://github.com/justinbois/bebi103',
+    url=url,
     download_url='https://github.com/justinbois/bebi103/tarball/' + __version__,
     license='BSD',
     classifiers=[
@@ -30,11 +65,11 @@ setup(
       'Intended Audience :: Developers',
       'Programming Language :: Python :: 3',
     ],
-    keywords='',
+    keywords=keywords,
     packages=find_packages(exclude=['docs', 'tests*']),
     include_package_data=True,
-    author='Justin Bois',
+    author=author,
     install_requires=install_requires,
     dependency_links=dependency_links,
-    author_email='bois@caltech.edu'
+    author_email=author_email
 )


### PR DESCRIPTION
Hey Justin!

I was talking with Sophie about software citation and thought it would be great if you could preserve this repository with CaltechDATA.  This PR includes a codemeta file, which adds more complete metadata to your repo.  Even if you don't want a codemeta file, you can easily set up software preservation using CaltechDATA:

1. Log into data.caltech.edu with your Caltech (access.caltech) account credentials.  
2. Select GitHub from the profile menu in the upper right hand side of the screen. 
3. Enter your GitHub credentials
4. Select the repository of interest (You might have to refresh the page for the buttons to activate).  5. Make a new release in GitHub.  

Let me know if you have any questions,

Tom