### PR TITLE
Add missing import

### DIFF
--- a/bebi103/image.py
+++ b/bebi103/image.py
@@ -19,7 +19,7 @@ import bokeh.plotting
 from matplotlib import path
 
 from . import viz
-
+from . import utils
 
 def imshow(
     im,


### PR DESCRIPTION
Calls to `utils._pearson_r` fail since utils isn't imported. 

https://github.com/justinbois/bebi103/blob/5f30c42d3b84d28994f3815b5fc6650baccafc35/bebi103/image.py#L1046
https://github.com/justinbois/bebi103/blob/5f30c42d3b84d28994f3815b5fc6650baccafc35/bebi103/image.py#L1139
https://github.com/justinbois/bebi103/blob/5f30c42d3b84d28994f3815b5fc6650baccafc35/bebi103/image.py#L1046